### PR TITLE
feature/重构clock_engine

### DIFF
--- a/custom/fixeddataengine.py
+++ b/custom/fixeddataengine.py
@@ -6,7 +6,7 @@ __author__ = 'keping.chu'
 import easyquotation
 from easyquant import PushBaseEngine
 import aiohttp
-from easyquant.easydealutils import time as work_time
+# from easyquant.easydealutils import time as work_time
 import time
 from easyquant.event_engine import Event
 import multiprocessing as mp
@@ -17,16 +17,16 @@ class FixedDataEngine(PushBaseEngine):
     EventType = 'custom'
     PushInterval = 15
 
-    def __init__(self, event_engine, watch_stocks=None, s='sina'):
+    def __init__(self, event_engine, clock_engine, watch_stocks=None, s='sina'):
 
         self.watch_stocks = watch_stocks
         self.s = s
         self.source = None
         self.__queue = mp.Queue(1000)
-        self.is_pause = False if work_time.is_tradetime_now() else True
+        self.is_pause = not clock_engine.is_tradetime_now()
         self._control_thread = Thread(target=self._process_control)
         self._control_thread.start()
-        super(FixedDataEngine, self).__init__(event_engine)
+        super(FixedDataEngine, self).__init__(event_engine, clock_engine)
 
     def _process_control(self):
 

--- a/custom/fixedmainengine.py
+++ b/custom/fixedmainengine.py
@@ -14,7 +14,6 @@ from threading import Thread, Lock
 
 from easyquant.multiprocess.strategy_wrapper import ProcessWrapper
 
-
 class FixedMainEngine(MainEngine):
 
     def __init__(self, broker, need_data='ht.json', quotation_engines=[FixedDataEngine],
@@ -37,7 +36,7 @@ class FixedMainEngine(MainEngine):
         positions = [p['stock_code'] for p in self.user.position]
         positions.extend(ext_stocks)
         for quotation_engine in quotation_engines:
-            self.quotation_engines.append(quotation_engine(self.event_engine, positions))
+            self.quotation_engines.append(quotation_engine(self.event_engine, self.clock_engine, positions))
 
     def load(self, names, strategy_file):
         with self.lock:

--- a/easyquant/easydealutils/time.py
+++ b/easyquant/easydealutils/time.py
@@ -80,26 +80,26 @@ def is_closing(now_time, start=datetime.time(14, 54, 30)):
     return False
 
 
-def calc_next_trade_time_delta_seconds():
-    now_time = datetime.datetime.now()
-    now = (now_time.hour, now_time.minute, now_time.second)
-    if now < (9, 15, 0):
-        next_trade_start = now_time.replace(hour=9, minute=15, second=0, microsecond=0)
-    elif (12, 0, 0) < now < (13, 0, 0):
-        next_trade_start = now_time.replace(hour=13, minute=0, second=0, microsecond=0)
-    elif now > (15, 0, 0):
-        distance_next_work_day = 1
-        while True:
-            target_day = now_time + timedelta(days=distance_next_work_day)
-            if is_holiday(target_day.strftime('%Y%m%d')):
-                distance_next_work_day += 1
-            else:
-                break
-
-        day_delta = timedelta(days=distance_next_work_day)
-        next_trade_start = (now_time + day_delta).replace(hour=9, minute=15,
-                                                          second=0, microsecond=0)
-    else:
-        return 0
-    time_delta = next_trade_start - now_time
-    return time_delta.total_seconds()
+# def calc_next_trade_time_delta_seconds():
+#     now_time = datetime.datetime.now()
+#     now = (now_time.hour, now_time.minute, now_time.second)
+#     if now < (9, 15, 0):
+#         next_trade_start = now_time.replace(hour=9, minute=15, second=0, microsecond=0)
+#     elif (12, 0, 0) < now < (13, 0, 0):
+#         next_trade_start = now_time.replace(hour=13, minute=0, second=0, microsecond=0)
+#     elif now > (15, 0, 0):
+#         distance_next_work_day = 1
+#         while True:
+#             target_day = now_time + timedelta(days=distance_next_work_day)
+#             if is_holiday(target_day.strftime('%Y%m%d')):
+#                 distance_next_work_day += 1
+#             else:
+#                 break
+#
+#         day_delta = timedelta(days=distance_next_work_day)
+#         next_trade_start = (now_time + day_delta).replace(hour=9, minute=15,
+#                                                           second=0, microsecond=0)
+#     else:
+#         return 0
+#     time_delta = next_trade_start - now_time
+#     return time_delta.total_seconds()

--- a/easyquant/main_engine.py
+++ b/easyquant/main_engine.py
@@ -24,7 +24,7 @@ class MainEngine:
     """主引擎，负责行情 / 事件驱动引擎 / 交易"""
 
     def __init__(self, broker, need_data='me.json', quotation_engines=None,
-                 log_handler=DefaultLogHandler()):
+                 log_handler=DefaultLogHandler(), now=None, tzinfo=None):
         """初始化事件 / 行情 引擎并启动事件引擎
         """
         # 登录账户
@@ -36,7 +36,7 @@ class MainEngine:
             log_handler.warn("券商账号信息文件 %s 不存在, easytrader 将不可用" % need_data)
 
         self.event_engine = EventEngine()
-        self.clock_engine = ClockEngine(self.event_engine)
+        self.clock_engine = ClockEngine(self.event_engine, now, tzinfo)
 
         quotation_engines = quotation_engines or [DefaultQuotationEngine]
 

--- a/easyquant/main_engine.py
+++ b/easyquant/main_engine.py
@@ -44,7 +44,7 @@ class MainEngine:
             quotation_engines = [quotation_engines]
         self.quotation_engines = []
         for quotation_engine in quotation_engines:
-            self.quotation_engines.append(quotation_engine(self.event_engine))
+            self.quotation_engines.append(quotation_engine(self.event_engine, self.clock_engine))
 
         # 保存读取的策略类
         self.strategies = OrderedDict()

--- a/easyquant/push_engine/base_engine.py
+++ b/easyquant/push_engine/base_engine.py
@@ -12,8 +12,9 @@ class BaseEngine:
     EventType = 'base'
     PushInterval = 1
 
-    def __init__(self, event_engine):
+    def __init__(self, event_engine, clock_engine):
         self.event_engine = event_engine
+        self.clock_engine = clock_engine
         self.is_active = True
         self.quotation_thread = Thread(target=self.push_quotation)
         self.quotation_thread.setDaemon(False)

--- a/easyquant/push_engine/clock_engine.py
+++ b/easyquant/push_engine/clock_engine.py
@@ -4,6 +4,7 @@ from threading import Thread
 import time
 import arrow
 from dateutil import tz
+from collections import deque
 
 from ..easydealutils import time as etime
 from ..event_engine import Event
@@ -13,6 +14,72 @@ class Clock:
     def __init__(self, trading_time, clock_event):
         self.trading_state = trading_time
         self.clock_event = clock_event
+
+
+class ClockIntervalHandler:
+    def __init__(self, clock_engine, interval, trading=True, call=None):
+        """
+        :param interval: float(minute)
+        :param trading: 在交易阶段才触发
+        :return:
+        """
+        self.clock_engine = clock_engine
+        self.clock_type = interval
+        self.interval = interval
+        self.second = int(interval * 60)
+        self.trading = trading
+        self.call = call or (lambda: None)
+
+    def is_active(self):
+        if self.trading:
+            if not self.clock_engine.trading_state:
+                return False
+        return int(self.clock_engine.now) % self.second == 0
+
+    def __eq__(self, other):
+        if isinstance(other, ClockIntervalHandler):
+            return self.interval == other.interval
+        else:
+            return False
+
+    def __hash__(self):
+        return self.second
+
+
+class ClockMomentHandler:
+    def __init__(self, clock_engine, clock_type, moment=None, makeup=False, call=None):
+        """
+        :param clock_type:
+        :param moment: datetime.time
+        :param makeup: 注册时,如果已经过了触发时机,是否立即触发
+        :return:
+        """
+        self.clock_engine = clock_engine
+        self.clock_type = clock_type
+        self.moment = moment
+        self.makeup = makeup
+        self.call = call or (lambda: None)
+        self.next_time = datetime.datetime.combine(
+            self.clock_engine.now_dt.date(),
+            self.moment,
+        )
+
+        if not self.makeup and self.is_active():
+            self.update_next_time()
+
+    def update_next_time(self):
+        """
+        下次激活时间
+        :return:
+        """
+        if self.is_active():
+            self.next_time = datetime.datetime.combine(
+                self.next_time.date() + datetime.timedelta(days=1),
+                self.moment
+            )
+
+    def is_active(self):
+        return self.next_time <= self.clock_engine.now_dt
 
 
 class ClockEngine:
@@ -25,7 +92,6 @@ class ClockEngine:
     def __init__(self, event_engine, now=None, tzinfo=None):
         """
         :param event_engine:
-        :param start_time:  issubclass(datetime.datetime) or arrow.Arrow 指定开始时间, 测试时可用.
         :param event_engine: tzinfo
         :return:
         """
@@ -33,12 +99,44 @@ class ClockEngine:
         self.tzinfo = tzinfo or tz.tzlocal()
         # 引擎启动的时间,默认为当前.测试时可手动设置模拟各个时间段.
         self.time_delta = self._delta(now)
-        self.start_time = self.now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        # self.start_time = self.now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
         self.event_engine = event_engine
         self.is_active = True
         self.clock_engine_thread = Thread(target=self.clocktick)
         self.sleep_time = 1
         self.trading_state = True if etime.is_tradetime(datetime.datetime.now()) else False
+        self.clock_moment_handlers = deque()
+        self.clock_interval_handlers = set()
+
+        self._init_clock_handler()
+
+    def _init_clock_handler(self):
+        """
+        注册默认的时钟事件
+        :return:
+        """
+
+        # 开盘事件
+        def open_():
+            self.trading_state = True
+
+        self._register_moment('open', datetime.time(9, tzinfo=self.tzinfo), True, open_)
+
+        # 中午休市
+        self._register_moment('pause', datetime.time(11, 30, tzinfo=self.tzinfo), True)
+
+        # 下午开盘
+        self._register_moment('continue', datetime.time(13, tzinfo=self.tzinfo), True)
+
+        # 收盘事件
+        def close():
+            self.trading_state = False
+
+        self._register_moment('close', datetime.time(15, tzinfo=self.tzinfo), True, close)
+
+        # 间隔事件
+        for interval in (0.5, 1, 5, 15, 30, 60):
+            self.register_interval(interval)
 
     def _delta(self, now):
         if now is None:
@@ -65,55 +163,96 @@ class ClockEngine:
         """
         return arrow.get(self.now).to(self.tzinfo)
 
+    def reset_now(self, now=None):
+        self.time_delta = self._delta(now)
+
     def start(self):
         self.clock_engine_thread.start()
 
     def clocktick(self):
         while self.is_active:
-            now_time = datetime.datetime.now()
-            self.tock(now_time)
+            self.tock()
             time.sleep(self.sleep_time)
 
-    def tock(self, now_time):
-        """
-        :param now_time: datetime.datetime()
-        :return:
-        """
-        min_seconds = 60
-        time_delta = now_time - self.start_time
-        seconds_delta = int(time_delta.total_seconds())
-
-        if etime.is_holiday(now_time):
+    def tock(self):
+        if etime.is_holiday(self.now_dt):
             pass  # 假日暂停时钟引擎
         else:
-            # 工作日，干活了
-            if etime.is_tradetime(now_time):
-                # 交易时间段
-                if self.trading_state is True:
-                    if etime.is_closing(now_time):
-                        self.push_event_type('closing')
+            self._tock()
 
-                    for delta in [0.5, 1, 5, 15, 30, 60]:
-                        if seconds_delta % (min_seconds * delta) == 0:
-                            self.push_event_type(delta)
+    def _tock(self):
+        # 间隔事件
+        for handler in self.clock_interval_handlers:
+            if handler.is_active():
+                handler.call()
+                self.push_event_type(handler)
+        # 时刻事件
+        while self.clock_moment_handlers:
+            clock_handler = self.clock_moment_handlers.pop()
+            if clock_handler.is_active():
+                clock_handler.call()
+                self.push_event_type(clock_handler)
+                clock_handler.update_next_time()
+                self.clock_moment_handlers.appendleft(clock_handler)
+            else:
+                self.clock_moment_handlers.append(clock_handler)
+                break
 
-                else:
-                    self.trading_state = True
-                    self.push_event_type('open')
+                # # 工作日，干活了
+                # if etime.is_tradetime(now_time):
+                #     # 交易时间段
+                #     if self.trading_state is True:
+                #         if etime.is_closing(now_time):
+                #             self.push_event_type('closing')
+                #
+                #         for delta in [0.5, 1, 5, 15, 30, 60]:
+                #             if seconds_delta % (min_seconds * delta) == 0:
+                #                 self.push_event_type(delta)
+                #
+                #     else:
+                #         self.trading_state = True
+                #         self.push_event_type('open')
+                #
+                # elif etime.is_pause(now_time):
+                #     self.push_event_type('pause')
+                #
+                # elif etime.is_continue(now_time):
+                #     self.push_event_type('continue')
+                #
+                # elif self.trading_state is True:
+                #     self.trading_state = False
+                #     self.push_event_type('close')
 
-            elif etime.is_pause(now_time):
-                self.push_event_type('pause')
-
-            elif etime.is_continue(now_time):
-                self.push_event_type('continue')
-
-            elif self.trading_state is True:
-                self.trading_state = False
-                self.push_event_type('close')
-
-    def push_event_type(self, etype):
-        event = Event(event_type=self.EventType, data=Clock(self.trading_state, etype))
+    def push_event_type(self, clock_handler):
+        event = Event(event_type=self.EventType, data=Clock(self.trading_state, clock_handler.clock_type))
         self.event_engine.put(event)
 
     def stop(self):
         self.is_active = False
+
+    def is_tradetime_now(self):
+        """
+        :return:
+        """
+        return etime.is_tradetime(self.now_dt)
+
+    def register_moment(self, clock_type, moment, makeup=False):
+        return self._register_moment(clock_type, moment, makeup)
+
+    def _register_moment(self, clock_type, moment, makeup=False, call=None):
+        handlers = list(self.clock_moment_handlers)
+        handler = ClockMomentHandler(self, clock_type, moment, makeup, call)
+        handlers.append(handler)
+
+        # 触发事件重新排序
+        handlers.sort(key=lambda h: h.next_time, reverse=True)
+        self.clock_moment_handlers = deque(handlers)
+        return handler
+
+    def register_interval(self, interval_minute, trading=True):
+        return self._register_interval(interval_minute, trading)
+
+    def _register_interval(self, interval_minute, trading=True, call=None):
+        handler = ClockIntervalHandler(self, interval_minute, trading, call)
+        self.clock_interval_handlers.add(handler)
+        return handler

--- a/easyquant/push_engine/clock_engine.py
+++ b/easyquant/push_engine/clock_engine.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 import datetime
 from threading import Thread
-
 import time
+import arrow
+from dateutil import tz
+
 from ..easydealutils import time as etime
 from ..event_engine import Event
 
@@ -14,16 +16,54 @@ class Clock:
 
 
 class ClockEngine:
-    """时间推送引擎"""
+    """
+    时间推送引擎
+    1. 提供统一的 now 时间戳.
+    """
     EventType = 'clock_tick'
 
-    def __init__(self, event_engine):
-        self.start_time = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    def __init__(self, event_engine, now=None, tzinfo=None):
+        """
+        :param event_engine:
+        :param start_time:  issubclass(datetime.datetime) or arrow.Arrow 指定开始时间, 测试时可用.
+        :param event_engine: tzinfo
+        :return:
+        """
+        # 默认使用当地时间的时区
+        self.tzinfo = tzinfo or tz.tzlocal()
+        # 引擎启动的时间,默认为当前.测试时可手动设置模拟各个时间段.
+        self.time_delta = self._delta(now)
+        self.start_time = self.now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
         self.event_engine = event_engine
         self.is_active = True
         self.clock_engine_thread = Thread(target=self.clocktick)
         self.sleep_time = 1
         self.trading_state = True if etime.is_tradetime(datetime.datetime.now()) else False
+
+    def _delta(self, now):
+        if now is None:
+            return 0
+        if now.tzinfo is None:
+            now = arrow.get(datetime.datetime(
+                now.year, now.month, now.day, now.hour, now.minute, now.second, now.microsecond, self.tzinfo,
+            ))
+
+        return (arrow.now() - now).total_seconds()
+
+    @property
+    def now(self):
+        """
+        now 时间戳统一接口
+        :return:
+        """
+        return time.time() - self.time_delta
+
+    @property
+    def now_dt(self):
+        """
+        :return: datetime 类型, 带时区的时间戳.建议使用 arrow 库
+        """
+        return arrow.get(self.now).to(self.tzinfo)
 
     def start(self):
         self.clock_engine_thread.start()
@@ -50,7 +90,6 @@ class ClockEngine:
             if etime.is_tradetime(now_time):
                 # 交易时间段
                 if self.trading_state is True:
-
                     if etime.is_closing(now_time):
                         self.push_event_type('closing')
 

--- a/easyquant/strategy/strategyTemplate.py
+++ b/easyquant/strategy/strategyTemplate.py
@@ -52,7 +52,6 @@ class StrategyTemplate:
          'turnover': '420004912',
          'volume': '206390073.351'}}
         """
-        pass
 
     def run(self, event):
         try:

--- a/easyquant/strategy/strategyTemplate.py
+++ b/easyquant/strategy/strategyTemplate.py
@@ -9,6 +9,7 @@ class StrategyTemplate:
     def __init__(self, user, log_handler, main_engine):
         self.user = user
         self.main_engine = main_engine
+        self.clock_engine = main_engine.clock_engine
         # 优先使用自定义 log 句柄, 否则使用主引擎日志句柄
         self.log = self.log_handler() or log_handler
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ anyjson
 aiohttp
 easytrader
 easyquotation
+arrow

--- a/strategies/策略1_Demo.py
+++ b/strategies/策略1_Demo.py
@@ -1,9 +1,23 @@
+import datetime as dt
+from dateutil import tz
 from easyquant import DefaultLogHandler
 from easyquant import StrategyTemplate
 
 
 class Strategy(StrategyTemplate):
     name = '测试策略1'
+
+    def init(self):
+        now = self.clock_engine.now_dt
+
+        # 注册时钟事件
+        clock_type = "盘尾"
+        moment = dt.time(14, 56, 30, tzinfo=tz.tzlocal())
+        self.clock_engine.register_moment(clock_type, moment)
+
+        # 注册时钟间隔事件, 不在交易阶段也会触发, clock_type == minute_interval
+        minute_interval = 1.5
+        self.clock_engine.register_interval(minute_interval, trading=False)
 
     def strategy(self, event):
         """:param event event.data 为所有股票的信息，结构如下

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 import easyquotation
+from easyquant.push_engine.clock_engine import ClockEngine
 
 import easyquant
 from easyquant import DefaultQuotationEngine, DefaultLogHandler, PushBaseEngine
@@ -48,6 +49,7 @@ log_type = 'stdout' if log_type_choose == '1' else 'file'
 log_filepath = input('请输入 log 文件记录路径\n: ') if log_type == 'file' else ''
 
 log_handler = DefaultLogHandler(name='测试', log_type=log_type, filepath=log_filepath)
+
 
 m = easyquant.MainEngine(broker, need_data, quotation_engines=[quotation_engine], log_handler=log_handler)
 m.load_strategy()

--- a/unitest_demo.py
+++ b/unitest_demo.py
@@ -243,6 +243,7 @@ class TestClock(BaseTest):
             # 记录补发
             if event.data.clock_event == clock_type:
                 self.active_times += 1
+
         self.main_engine.event_engine.register(ClockEngine.EventType, clock)
 
         self.main_engine.event_engine.start()
@@ -311,8 +312,6 @@ class TestClock(BaseTest):
             time.sleep(0.001)
 
         # 等待事件引擎处理
-        for k, v in counts.items():
-            print(k, [d.strftime("%H:%M:%S") for d in v])
         self.main_engine.event_engine.stop()
 
         # 开盘收盘, 中午开盘休盘, 必定会触发1次
@@ -323,6 +322,6 @@ class TestClock(BaseTest):
 
         # 核对次数, 休市的时候不会统计
         self.assertEqual(len(counts[60]), 15 - 9 + 1 - len(["9:00"]))
-        self.assertEqual(len(counts[30]), (15 - 9) * 2 + 1 - len(["9:00", "11:30", "12:00", "12:30", "15:00"]))
+        self.assertEqual(len(counts[30]), (15 - 9) * 2 + 1 - len(["9:00"]))
         self.assertEqual(len(counts[15]), (15 - 9) * 4 + 1 -
-                         len(["9:00", "9:15", "11:30", "11:45", "12:00", "12:15", "12:30", "12:45", "15:00"]))
+                         len(["9:00"]))

--- a/unitest_demo.py
+++ b/unitest_demo.py
@@ -3,10 +3,13 @@
 演示如何进行单元测试
 """
 import time
+import arrow
 import unittest
 import datetime
+from dateutil import tz
 from easyquant.main_engine import MainEngine
 from easyquant.push_engine.clock_engine import ClockEngine
+from easyquant.event_engine import EventEngine
 
 __author__ = 'Shawn'
 
@@ -55,6 +58,19 @@ class TestClock(BaseTest):
         执行每个单元测试 后 都要执行的逻辑
         :return:
         """
+
+    def test_set_now(self):
+        """
+        重设 clock_engine 的时间
+        :return:
+        """
+
+        tzinfo = tz.tzlocal()
+        now = datetime.datetime(2016, 5, 5, 8, 59, 00, tzinfo)
+        clock_engien = ClockEngine(EventEngine(), now, tzinfo)
+
+        # 去掉微秒误差后比较
+        self.assertEqual(clock_engien.now_dt.replace(microsecond=0), now)
 
     def test_tick(self):
         """

--- a/unitest_demo.py
+++ b/unitest_demo.py
@@ -3,12 +3,12 @@
 演示如何进行单元测试
 """
 import time
-import arrow
 import unittest
 import datetime
+import threading
 from dateutil import tz
 from easyquant.main_engine import MainEngine
-from easyquant.push_engine.clock_engine import ClockEngine
+from easyquant.push_engine.clock_engine import ClockEngine, ClockMomentHandler
 from easyquant.event_engine import EventEngine
 
 __author__ = 'Shawn'
@@ -47,8 +47,12 @@ class TestClock(BaseTest):
         执行每个单元测试 前 都要执行的逻辑
         :return:
         """
+        self.trading_date = datetime.date(2016, 5, 5)
+        self.time = datetime.time(0, 0, 0, tzinfo=tz.tzlocal())
+
+        now = datetime.datetime.combine(self.trading_date, self.time)
         # 此处重新定义 main_engine
-        self._main_engine = MainEngine('ht')
+        self._main_engine = MainEngine('ht', now=now)
 
         # 设置为不在交易中
         self.clock_engine.trading_state = False
@@ -66,11 +70,199 @@ class TestClock(BaseTest):
         """
 
         tzinfo = tz.tzlocal()
-        now = datetime.datetime(2016, 5, 5, 8, 59, 00, tzinfo)
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(8, 59, 00, tzinfo=tzinfo),
+        )
         clock_engien = ClockEngine(EventEngine(), now, tzinfo)
 
         # 去掉微秒误差后比较
         self.assertEqual(clock_engien.now_dt.replace(microsecond=0), now)
+
+    def test_reset_now(self):
+        """
+        重设时钟引擎当前时间为其他时间点
+        :return:
+        """
+        tzinfo = tz.tzlocal()
+        clock_engien = ClockEngine(EventEngine())
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(8, 59, 00, tzinfo=tzinfo),
+        )
+        clock_engien.reset_now(now)
+
+        # 去掉微秒误差后比较
+        self.assertEqual(clock_engien.now_dt.replace(microsecond=0), now)
+
+        # 重设为当前时间
+        clock_engien.reset_now()
+        now = datetime.datetime.now(tzinfo).replace(microsecond=0)
+
+        # 去掉微秒误差后比较
+        self.assertEqual(clock_engien.now_dt.replace(microsecond=0), now)
+
+    def test_clock_moment_is_active(self):
+        # 设置时间
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(23, 59, 58, tzinfo=tz.tzlocal()),
+        )
+        self.clock_engine.reset_now(now)
+
+        # 触发前, 注册时间事件
+        moment = datetime.time(23, 59, 59, tzinfo=tz.tzlocal())
+        cmh = ClockMomentHandler(self.clock_engine, 'test', moment)
+        # 确认未触发
+        self.assertFalse(cmh.is_active())
+
+        # 将系统时间设置为触发时间
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(23, 59, 59, tzinfo=tz.tzlocal())
+        )
+        self.clock_engine.reset_now(now)
+        # 确认触发
+        self.assertTrue(cmh.is_active())
+
+    def test_clock_update_next_time(self):
+        # 设置时间
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(23, 59, 58, tzinfo=tz.tzlocal())
+        )
+        self.clock_engine.reset_now(now)
+
+        # 触发前, 注册时间事件
+        moment = datetime.time(23, 59, 59, tzinfo=tz.tzlocal())
+        cmh = ClockMomentHandler(self.clock_engine, 'test', moment)
+        # 确认未触发
+        self.assertFalse(cmh.is_active())
+
+        # 将系统时间设置为触发时间
+        now = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(23, 59, 59, tzinfo=tz.tzlocal())
+        )
+        self.clock_engine.reset_now(now)
+        # 确认触发
+        self.assertTrue(cmh.is_active())
+
+        # 更新下次触发时间
+        cmh.update_next_time()
+        # 确认未触发
+        self.assertFalse(cmh.is_active())
+
+    def test_register_clock_moment_makeup(self):
+        # 测试补发
+        self.register_clock_moent_makeup(True)
+
+    def test_register_clock_moment_not_makeup(self):
+        # 测试不补发
+        self.register_clock_moent_makeup(False)
+
+    def register_clock_moent_makeup(self, makeup):
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(23, 59, 59, tzinfo=tz.tzlocal())
+        )
+        self.clock_engine.reset_now(begin)
+
+        # 注册时刻一个超时事件
+        moment = datetime.time(0, 0, 0, tzinfo=tz.tzlocal())
+        self.clock_engine.register_moment('test', moment, makeup=makeup)
+
+        self.test_active = False
+
+        def clock(event):
+            # 记录补发
+            if event.data.clock_event == 'test':
+                self.test_active = True
+
+        self.main_engine.event_engine.register(ClockEngine.EventType, clock)
+
+        # 开启事件引擎
+        self.main_engine.event_engine.start()
+        self.clock_engine.tock()
+
+        time.sleep(0.1)
+        self.main_engine.event_engine.stop()
+
+        # 确认补发
+        self.assertEqual(self.test_active, makeup)
+
+    def test_register_clock_interval_trading_true(self):
+        # 交易触发, 交易阶段
+        trading = True
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(9, 15, 0, tzinfo=tz.tzlocal())
+        )
+        # 确认在交易中
+        self.register_clock_interval(begin, trading, 1)
+        self.assertTrue(self.clock_engine.trading_state)
+
+    def test_register_clock_interval_not_trading_true(self):
+        # 交易触发, 非交易阶段
+        trading = True
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(15, 15, 0, tzinfo=tz.tzlocal())
+        )
+        # 确认在交易中
+        self.register_clock_interval(begin, trading, 0)
+        self.assertFalse(self.clock_engine.trading_state)
+
+    def test_register_clock_interval_trading_false(self):
+        # 非交易触发, 交易阶段
+        trading = False
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(9, 15, 0, tzinfo=tz.tzlocal())
+        )
+        # 确认在交易中
+        self.register_clock_interval(begin, trading, 1)
+        self.assertTrue(self.clock_engine.trading_state)
+
+    def test_register_clock_interval_not_trading_false(self):
+        # 非交易触发, 非交易阶段
+        trading = False
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(15, 15, 0, tzinfo=tz.tzlocal())
+        )
+        # 确认在交易中
+        self.register_clock_interval(begin, trading, 1)
+        self.assertFalse(self.clock_engine.trading_state)
+
+    def register_clock_interval(self, begin, trading, active_times):
+        self.clock_engine.reset_now(begin)
+        self.active_times = 0
+
+        def clock(event):
+            # 记录补发
+            if event.data.clock_event == clock_type:
+                self.active_times += 1
+        self.main_engine.event_engine.register(ClockEngine.EventType, clock)
+
+        self.main_engine.event_engine.start()
+        self.clock_engine.tock()
+
+        clock_type = minute_interval = 2.5
+        # 注册事件
+        handler = self.clock_engine.register_interval(minute_interval, trading)
+        # 确定已经添加到列表
+        self.assertIn(handler, self.clock_engine.clock_interval_handlers)
+
+        # 开启事件引擎
+        for sec in range(int(minute_interval * 60)):
+            now = begin + datetime.timedelta(seconds=sec)
+            self.clock_engine.reset_now(now)
+            self.clock_engine.tock()
+        time.sleep(1)
+        self.main_engine.event_engine.stop()
+
+        self.assertEqual(self.active_times, active_times)
 
     def test_tick(self):
         """
@@ -80,24 +272,23 @@ class TestClock(BaseTest):
         """
         # 各个时间间隔的触发次数计数
         counts = {
-            0.5: 0,
-            1: 0,
-            5: 0,
-            15: 0,
-            30: 0,
-            60: 0,
-            "open": 0,
-            "pause": 0,
-            "continue": 0,
-            "closing": 0,
-            "close": 0,
+            0.5: [],
+            1: [],
+            5: [],
+            15: [],
+            30: [],
+            60: [],
+            "open": [],
+            "pause": [],
+            "continue": [],
+            "close": [],
         }
 
         def count(event):
             # 时钟引擎必定在上述的类型中
             self.assertIn(event.data.clock_event, counts)
             # 计数
-            counts[event.data.clock_event] += 1
+            counts[event.data.clock_event].append(self.clock_engine.now_dt)
 
         # 注册一个响应时钟事件的函数
         self.main_engine.event_engine.register(ClockEngine.EventType, count)
@@ -106,30 +297,32 @@ class TestClock(BaseTest):
         self.main_engine.event_engine.start()
 
         # 模拟从开市前1分钟, 即8:59分, 到休市后1分钟的每秒传入时钟接口
-        begin = datetime.datetime(2016, 5, 5, 8, 59)
+        begin = datetime.datetime.combine(
+            self.trading_date,
+            datetime.time(8, 59, tzinfo=self.clock_engine.tzinfo)
+        )
         hours = 15 - 9
         mins = hours * 60 + 2
         seconds = 60 * mins
         for secs in range(seconds):
-            now_time = begin + datetime.timedelta(seconds=secs)
-            self.clock_engine.tock(now_time)
+            now = begin + datetime.timedelta(seconds=secs)
+            self.clock_engine.reset_now(now)
+            self.clock_engine.tock()
+            time.sleep(0.001)
 
         # 等待事件引擎处理
-        time.sleep(10)
-        print(counts)
+        for k, v in counts.items():
+            print(k, [d.strftime("%H:%M:%S") for d in v])
         self.main_engine.event_engine.stop()
 
-        # 核对次数, 休市的时候不会统计
-        self.assertEqual(counts[60], 15 - 9 + 1 - len(["9:00", "12:00", "15:00"]))
-        self.assertEqual(counts[30], (15 - 9) * 2 + 1 - len(["9:00", "11:30", "12:00", "12:30", "15:00"]))
-        self.assertEqual(counts[15],
-                         (15 - 9) * 4 + 1 - len(["9:00", "9:15", "11:30", "11:45", "12:00", "12:15", "12:30",
-                                                 "12:45", "15:00"]))
+        # 开盘收盘, 中午开盘休盘, 必定会触发1次
+        self.assertEqual(len(counts['open']), 1)
+        self.assertEqual(len(counts['pause']), 1)
+        self.assertEqual(len(counts['continue']), 1)
+        self.assertEqual(len(counts['close']), 1)
 
-        # 开盘收盘, 中午开盘休盘, 必定会触发1次, 如果报错,说明是因为当前时间处于非交易日
-        self.assertEqual(counts['open'], 1)
-        self.assertEqual(counts['closing'], 330)
-        self.assertEqual(counts['close'], 1)
-        # 目前的时钟引擎会一直推送 pause 和 continue
-        self.assertEqual(counts['pause'], 5370)
-        self.assertEqual(counts['continue'], 30)
+        # 核对次数, 休市的时候不会统计
+        self.assertEqual(len(counts[60]), 15 - 9 + 1 - len(["9:00"]))
+        self.assertEqual(len(counts[30]), (15 - 9) * 2 + 1 - len(["9:00", "11:30", "12:00", "12:30", "15:00"]))
+        self.assertEqual(len(counts[15]), (15 - 9) * 4 + 1 -
+                         len(["9:00", "9:15", "11:30", "11:45", "12:00", "12:15", "12:30", "12:45", "15:00"]))


### PR DESCRIPTION
- 特性
  1. 统一的 now 时间戳接口。
  2. 自定义系统时间，以便统一测试时的时间戳。
  3. 给策略提供时间事件注册的接口。
  4. 默认以当地时间作为时区，datetime 对象计算时需要给定时区。
  5. 时钟事件有时刻，和间隔两种。
  6. 单元测试完整地模拟一个交易日。
