### PR TITLE
Fix/直接使用 mock 重设单元测试中的时间戳

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ m = easyquant.MainEngine(broker, need_data, quotation_engine=[DefaultQuotationEn
 #### 时间戳单元测试
 
 1. 请通过 clock_engine 中的 .now 或者 .now_dt 接口,以及 time.time() 接口来获得时间戳.
-2. 通过上述接口获得时间戳,可以在单元测试中模拟某个时刻或者一段时间,详见单元测试 [test_set_now](https://github.com/lamter/easyquant/blob/master/unitest_demo.py)
+2. 通过上述接口获得时间戳,可以在单元测试中模拟某个时刻或者一段时间,详见单元测试 [test_set_now](https://github.com/shidenggui/easyquant/blob/master/unitest_demo.py)
 
 ```python
 from unittest import mock

--- a/README.md
+++ b/README.md
@@ -307,3 +307,14 @@ from easyquant import DefaultQuotationEngine
 
 m = easyquant.MainEngine(broker, need_data, quotation_engine=[DefaultQuotationEngine, LFEngine, OtherEngine])
 ```
+
+#### 时间戳单元测试
+
+1. 请通过 clock_engine 中的 .now 或者 .now_dt 接口,以及 time.time() 接口来获得时间戳.
+2. 通过上述接口获得时间戳,可以在单元测试中模拟某个时刻或者一段时间,详见
+
+```python
+from easyquant import DefaultQuotationEngine
+
+m = easyquant.MainEngine(broker, need_data, quotation_engine=[DefaultQuotationEngine, LFEngine, OtherEngine])
+```

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ m = easyquant.MainEngine(broker, need_data, quotation_engine=[DefaultQuotationEn
 #### 时间戳单元测试
 
 1. 请通过 clock_engine 中的 .now 或者 .now_dt 接口,以及 time.time() 接口来获得时间戳.
-2. 通过上述接口获得时间戳,可以在单元测试中模拟某个时刻或者一段时间,详见单元测试[test_set_now](*https://github.com/lamter/easyquant/blob/master/unitest_demo.py)
+2. 通过上述接口获得时间戳,可以在单元测试中模拟某个时刻或者一段时间,详见单元测试 [test_set_now](https://github.com/lamter/easyquant/blob/master/unitest_demo.py)
 
 ```python
 from unittest import mock

--- a/easyquant/main_engine.py
+++ b/easyquant/main_engine.py
@@ -26,7 +26,7 @@ class MainEngine:
     """主引擎，负责行情 / 事件驱动引擎 / 交易"""
 
     def __init__(self, broker=None, need_data=None, quotation_engines=None,
-                 log_handler=DefaultLogHandler(), now=None, tzinfo=None):
+                 log_handler=DefaultLogHandler(), tzinfo=None):
         """初始化事件 / 行情 引擎并启动事件引擎
         """
         self.log = log_handler
@@ -46,7 +46,7 @@ class MainEngine:
             self.log.info('选择了无交易模式')
 
         self.event_engine = EventEngine()
-        self.clock_engine = ClockEngine(self.event_engine, now, tzinfo)
+        self.clock_engine = ClockEngine(self.event_engine, tzinfo)
 
         quotation_engines = quotation_engines or [DefaultQuotationEngine]
 

--- a/easyquant/push_engine/clock_engine.py
+++ b/easyquant/push_engine/clock_engine.py
@@ -101,7 +101,7 @@ class ClockEngine:
     """
     EventType = 'clock_tick'
 
-    def __init__(self, event_engine, now=None, tzinfo=None):
+    def __init__(self, event_engine, tzinfo=None):
         """
         :param event_engine:
         :param event_engine: tzinfo
@@ -109,9 +109,7 @@ class ClockEngine:
         """
         # 默认使用当地时间的时区
         self.tzinfo = tzinfo or tz.tzlocal()
-        # 引擎启动的时间,默认为当前.测试时可手动设置模拟各个时间段.
-        self.time_delta = self._delta(now)
-        # self.start_time = self.now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
         self.event_engine = event_engine
         self.is_active = True
         self.clock_engine_thread = Thread(target=self.clocktick)
@@ -150,15 +148,15 @@ class ClockEngine:
         for interval in (0.5, 1, 5, 15, 30, 60):
             self.register_interval(interval)
 
-    def _delta(self, now):
-        if now is None:
-            return 0
-        if now.tzinfo is None:
-            now = arrow.get(datetime.datetime(
-                    now.year, now.month, now.day, now.hour, now.minute, now.second, now.microsecond, self.tzinfo,
-            ))
-
-        return (arrow.now() - now).total_seconds()
+    # def _delta(self, now):
+    #     if now is None:
+    #         return 0
+    #     if now.tzinfo is None:
+    #         now = arrow.get(datetime.datetime(
+    #                 now.year, now.month, now.day, now.hour, now.minute, now.second, now.microsecond, self.tzinfo,
+    #         ))
+    #
+    #     return (arrow.now() - now).total_seconds()
 
     @property
     def now(self):
@@ -166,7 +164,7 @@ class ClockEngine:
         now 时间戳统一接口
         :return:
         """
-        return time.time() - self.time_delta
+        return time.time()
 
     @property
     def now_dt(self):
@@ -175,13 +173,13 @@ class ClockEngine:
         """
         return arrow.get(self.now).to(self.tzinfo)
 
-    def reset_now(self, now=None):
-        """
-        调试用接口,请勿在生产环境使用
-        :param now:
-        :return:
-        """
-        self.time_delta = self._delta(now)
+    # def reset_now(self, now=None):
+    #     """
+    #     调试用接口,请勿在生产环境使用
+    #     :param now:
+    #     :return:
+    #     """
+    #     self.time_delta = self._delta(now)
 
     def start(self):
         self.clock_engine_thread.start()


### PR DESCRIPTION
- change : 去掉了 clock_engine 中重设时间戳的函数
- add : 增加了单元测试中使用 mock 来更改时间戳的功能
- add : 增加了使用 mock 更改时间戳来构建单元测试的例子及说明
